### PR TITLE
Add information for three private universities in Ankara, Turkey

### DIFF
--- a/world_universities_and_domains.json
+++ b/world_universities_and_domains.json
@@ -119570,5 +119570,41 @@
             "universite-paris-saclay.fr"
         ],
         "country": "France"
+    },
+    {
+        "web_pages": [
+            "https://www.ostimteknik.edu.tr"
+        ],
+        "name": "OSTIM Technical University",
+        "alpha_two_code": "TR",
+        "state-province": null,
+        "domains": [
+            "ostimteknik.edu.tr"
+        ],
+        "country": "Turkey"
+    },
+    {
+        "web_pages": [
+            "https://ankaramedipol.edu.tr"
+        ],
+        "name": "Ankara Medipol University",
+        "alpha_two_code": "TR",
+        "state-province": null,
+        "domains": [
+            "ankaramedipol.edu.tr"
+        ],
+        "country": "Turkey"
+    },
+    {
+        "web_pages": [
+            "https://ankarabilim.edu.tr"
+        ],
+        "name": "Ankara Science University",
+        "alpha_two_code": "TR",
+        "state-province": null,
+        "domains": [
+            "ankarabilim.edu.tr"
+        ],
+        "country": "Turkey"
     }
 ]


### PR DESCRIPTION
Include Ankara Medipol University, Ankara Science University, and Ostim Technical University data